### PR TITLE
customize configuration for HTTP / HTTPS issue

### DIFF
--- a/resources/tomcat/conf/server.xml
+++ b/resources/tomcat/conf/server.xml
@@ -21,7 +21,7 @@
         <Connector port='${http.port}' bindOnInit='false' connectionTimeout='20000'/>
 
         <Engine defaultHost='localhost' name='Catalina'>
-            <Valve className='org.apache.catalina.valves.RemoteIpValve' protocolHeader='x-forwarded-proto'/>
+            <Valve className='org.apache.catalina.valves.RemoteIpValve' protocolHeader='x-forwarded-proto' internalProxies='.*' />
             <Valve className='com.gopivotal.cloudfoundry.tomcat.logging.access.CloudFoundryAccessLoggingValve'
                    pattern='[ACCESS] %{org.apache.catalina.AccessLog.RemoteAddr}r %l %t %D %F %B %S vcap_request_id:%{X-Vcap-Request-Id}i'
                    enabled='${access.logging.enabled}'/>


### PR DESCRIPTION
Add the internalProxies='.*' configuration option to the RemoteIpValve to make tomcat trust the proxy addresses that Bluemix uses.